### PR TITLE
build: set os.environ['PKG_CONFIG_PATH']

### DIFF
--- a/wscript
+++ b/wscript
@@ -2,6 +2,9 @@
 VERSION='0.1'
 APPNAME="ndn-traffic-generator"
 
+from waflib import Utils
+import os
+
 def options(opt):
     opt.load(['compiler_cxx', 'gnu_dirs'])
     opt.load(['default-compiler-flags'], tooldir=['.waf-tools'])
@@ -9,6 +12,9 @@ def options(opt):
 def configure(conf):
     conf.load(['compiler_cxx', 'gnu_dirs',
                'default-compiler-flags'])
+    
+    if 'PKG_CONFIG_PATH' not in os.environ:
+        os.environ['PKG_CONFIG_PATH'] = Utils.subst_vars('${LIBDIR}/pkgconfig', conf.env)
     conf.check_cfg(package='libndn-cxx', args=['--cflags', '--libs'],
                    uselib_store='NDN_CXX', mandatory=True)
 


### PR DESCRIPTION
“PKG_CONFIG_PATH” may not be in os.environ, which will result in “libndn-cxx not found”.