### PR TITLE
Changed m_trafficPercentage from long to float

### DIFF
--- a/src/ndn-traffic-client.cpp
+++ b/src/ndn-traffic-client.cpp
@@ -177,7 +177,7 @@ private:
       }
 
       if (parameter == "TrafficPercentage") {
-        m_trafficPercentage = std::stoul(value);
+        m_trafficPercentage = std::stouf(value);
       }
       else if (parameter == "Name") {
         m_name = value;


### PR DESCRIPTION
On line 180, stoul was changed to stouf. This is because the long data type does not accept fractional values. This also changes cumulativePercentage to a float on line 481.